### PR TITLE
RTHandle support

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ Other custom effects in samples but not used in screenshots:
 
 ## Compatibility
 
-* Unity 2020.2
-* URP 10.2.2
+This branch is under development and it targets:
 
-**Note:** There is a branch with support for URP 8.2.0 (Unity 2020.1) which you can find [here](https://github.com/yahiaetman/URPCustomPostProcessingStack/tree/URP-8.2.0).
+* Unity 2021.2 & 2021.3
+* URP 12.1
 
 ## Features
 

--- a/Runtime/RenderFeatures/CustomPostProcess.cs
+++ b/Runtime/RenderFeatures/CustomPostProcess.cs
@@ -1,7 +1,8 @@
 using System;
 using System.Collections.Generic;
 
-namespace UnityEngine.Rendering.Universal.PostProcessing {
+namespace UnityEngine.Rendering.Universal.PostProcessing
+{
 
     /// <summary>
     /// This render feature is responsible for:
@@ -21,7 +22,8 @@ namespace UnityEngine.Rendering.Universal.PostProcessing {
         /// The settings for the custom post processing render feature.
         /// </summary>
         [Serializable]
-        public class CustomPostProcessSettings {
+        public class CustomPostProcessSettings
+        {
 
             /// <summary>
             /// Three list (one for each injection point) that holds the custom post processing renderers in order of execution during the render pass
@@ -29,7 +31,8 @@ namespace UnityEngine.Rendering.Universal.PostProcessing {
             [SerializeField]
             public List<string> renderersAfterOpaqueAndSky, renderersBeforePostProcess, renderersAfterPostProcess;
 
-            public CustomPostProcessSettings(){
+            public CustomPostProcessSettings()
+            {
                 renderersAfterOpaqueAndSky = new List<string>();
                 renderersBeforePostProcess = new List<string>();
                 renderersAfterPostProcess = new List<string>();
@@ -58,17 +61,21 @@ namespace UnityEngine.Rendering.Universal.PostProcessing {
             //     Debug.LogWarning("The CustomPostProcess renderer feature supports the UniversalRenderer only");
             //     return;
             // }
-            
+
             // Only inject passes if post processing is enabled
-            if(renderingData.cameraData.postProcessEnabled) {
+            if (renderingData.cameraData.postProcessEnabled)
+            {
                 // For each pass, only inject if there is at least one custom post-processing renderer class in it.
-                if(m_AfterOpaqueAndSky.HasPostProcessRenderers && m_AfterOpaqueAndSky.PrepareRenderers(ref renderingData)){
+                if (m_AfterOpaqueAndSky.HasPostProcessRenderers && m_AfterOpaqueAndSky.PrepareRenderers(ref renderingData))
+                {
                     renderer.EnqueuePass(m_AfterOpaqueAndSky);
                 }
-                if(m_BeforePostProcess.HasPostProcessRenderers && m_BeforePostProcess.PrepareRenderers(ref renderingData)){
+                if (m_BeforePostProcess.HasPostProcessRenderers && m_BeforePostProcess.PrepareRenderers(ref renderingData))
+                {
                     renderer.EnqueuePass(m_BeforePostProcess);
                 }
-                if(m_AfterPostProcess.HasPostProcessRenderers && m_AfterPostProcess.PrepareRenderers(ref renderingData)){
+                if (m_AfterPostProcess.HasPostProcessRenderers && m_AfterPostProcess.PrepareRenderers(ref renderingData))
+                {
                     renderer.EnqueuePass(m_AfterPostProcess);
                 }
             }
@@ -85,28 +92,33 @@ namespace UnityEngine.Rendering.Universal.PostProcessing {
             m_BeforePostProcess = new CustomPostProcessRenderPass(CustomPostProcessInjectionPoint.BeforePostProcess, InstantiateRenderers(settings.renderersBeforePostProcess, shared));
             m_AfterPostProcess = new CustomPostProcessRenderPass(CustomPostProcessInjectionPoint.AfterPostProcess, InstantiateRenderers(settings.renderersAfterPostProcess, shared));
         }
-        
+
         /// <summary>
         /// Converts the class name (AssemblyQualifiedName) to an instance. Filters out types that don't exist or don't match the requirements.
         /// </summary>
         /// <param name="names">The list of assembly-qualified class names</param>
         /// <param name="shared">Dictionary of shared instances keyed by class name</param>
         /// <returns>List of renderers</returns>
-        private List<CustomPostProcessRenderer> InstantiateRenderers(List<String> names, Dictionary<string, CustomPostProcessRenderer> shared){
+        private List<CustomPostProcessRenderer> InstantiateRenderers(List<String> names, Dictionary<string, CustomPostProcessRenderer> shared)
+        {
             var renderers = new List<CustomPostProcessRenderer>(names.Count);
-            foreach(var name in names){
-                if(shared.TryGetValue(name, out var renderer)){
+            foreach (var name in names)
+            {
+                if (shared.TryGetValue(name, out var renderer))
+                {
                     renderers.Add(renderer);
-                } else {
+                }
+                else
+                {
                     var type = Type.GetType(name);
-                    if(type == null || !type.IsSubclassOf(typeof(CustomPostProcessRenderer))) continue;
+                    if (type == null || !type.IsSubclassOf(typeof(CustomPostProcessRenderer))) continue;
                     var attribute = CustomPostProcessAttribute.GetAttribute(type);
-                    if(attribute == null) continue;
+                    if (attribute == null) continue;
 
                     renderer = Activator.CreateInstance(type) as CustomPostProcessRenderer;
                     renderers.Add(renderer);
-                    
-                    if(attribute.ShareInstance)
+
+                    if (attribute.ShareInstance)
                         shared.Add(name, renderer);
                 }
             }
@@ -142,12 +154,7 @@ namespace UnityEngine.Rendering.Universal.PostProcessing {
         /// <summary>
         /// Array of 2 intermediate render targets used to hold intermediate results.
         /// </summary>
-        private RenderTargetHandle[] m_Intermediate;
-
-        /// <summary>
-        /// Indentifies whether the intermediate render targets are allocated or not.
-        /// </summary>
-        private bool[] m_IntermediateAllocated;
+        private RTHandle[] m_Intermediate;
 
         /// <summary>
         /// The texture descriptor for the intermediate render targets.
@@ -164,16 +171,20 @@ namespace UnityEngine.Rendering.Universal.PostProcessing {
         /// </summary>
         public bool HasPostProcessRenderers => m_PostProcessRenderers.Count != 0;
 
+        private readonly string[] _IntermediateRTNames = new string[2] { "_IntermediateRT0", "_IntermediateRT1" };
+
         /// <summary>
         /// Construct the custom post-processing render pass
         /// </summary>
         /// <param name="injectionPoint">The post processing injection point</param>
         /// <param name="classes">The list of classes for the renderers to be executed by this render pass</param>
-        public CustomPostProcessRenderPass(CustomPostProcessInjectionPoint injectionPoint, List<CustomPostProcessRenderer> renderers){
+        public CustomPostProcessRenderPass(CustomPostProcessInjectionPoint injectionPoint, List<CustomPostProcessRenderer> renderers)
+        {
             this.injectionPoint = injectionPoint;
             this.m_ProfilingSamplers = new List<ProfilingSampler>(renderers.Count);
             this.m_PostProcessRenderers = renderers;
-            foreach(var renderer in renderers){
+            foreach (var renderer in renderers)
+            {
                 // Get renderer name and add it to the names list
                 var attribute = CustomPostProcessAttribute.GetAttribute(renderer.GetType());
                 m_ProfilingSamplers.Add(new ProfilingSampler(attribute?.Name));
@@ -181,12 +192,13 @@ namespace UnityEngine.Rendering.Universal.PostProcessing {
             // Pre-allocate a list for active renderers
             this.m_ActivePostProcessRenderers = new List<int>(renderers.Count);
             // Set render pass event and name based on the injection point.
-            switch(injectionPoint){
-                case CustomPostProcessInjectionPoint.AfterOpaqueAndSky: 
-                    renderPassEvent = RenderPassEvent.AfterRenderingSkybox; 
+            switch (injectionPoint)
+            {
+                case CustomPostProcessInjectionPoint.AfterOpaqueAndSky:
+                    renderPassEvent = RenderPassEvent.AfterRenderingSkybox;
                     m_PassName = "Custom PostProcess after Opaque & Sky";
                     break;
-                case CustomPostProcessInjectionPoint.BeforePostProcess: 
+                case CustomPostProcessInjectionPoint.BeforePostProcess:
                     renderPassEvent = RenderPassEvent.BeforeRenderingPostProcessing;
                     m_PassName = "Custom PostProcess before PostProcess";
                     break;
@@ -198,44 +210,27 @@ namespace UnityEngine.Rendering.Universal.PostProcessing {
                     break;
             }
             // Initialize the IDs and allocation state of the intermediate render targets
-            m_Intermediate = new RenderTargetHandle[2];
-            m_Intermediate[0].Init("_IntermediateRT0");
-            m_Intermediate[1].Init("_IntermediateRT1");
-            m_IntermediateAllocated = new bool[2];
-            m_IntermediateAllocated[0] = false;
-            m_IntermediateAllocated[1] = false;
-        }
-
-        /// <summary>
-        /// Gets the corresponding intermediate RT and allocates it if not already allocated
-        /// </summary>
-        /// <param name="cmd">The command buffer to use for allocation</param>
-        /// <param name="index">The intermediate RT index</param>
-        /// <returns></returns>
-        private RenderTargetIdentifier GetIntermediate(CommandBuffer cmd, int index){
-            if(!m_IntermediateAllocated[index]){
-                cmd.GetTemporaryRT(m_Intermediate[index].id, m_IntermediateDesc);
-                m_IntermediateAllocated[index] = true;
-            }
-            return m_Intermediate[index].Identifier();
-        }
-
-        /// <summary>
-        /// Release allocated intermediate RTs
-        /// </summary>
-        /// <param name="cmd">The command buffer to use for deallocation</param>
-        private void CleanupIntermediate(CommandBuffer cmd){
-            for(int index = 0; index < 2; ++index){
-                if(m_IntermediateAllocated[index]){
-                    cmd.ReleaseTemporaryRT(m_Intermediate[index].id);
-                    m_IntermediateAllocated[index] = false;
-                }
-            }
+            m_Intermediate = new RTHandle[2];
         }
 
         public override void OnCameraSetup(CommandBuffer cmd, ref RenderingData renderingData)
         {
             base.OnCameraSetup(cmd, ref renderingData);
+            // Copy camera target description for intermediate RTs. Disable multisampling and depth buffer for the intermediate targets.
+            m_IntermediateDesc = renderingData.cameraData.cameraTargetDescriptor;
+            m_IntermediateDesc.msaaSamples = 1;
+            m_IntermediateDesc.depthBufferBits = 0;
+            m_Intermediate[0] = RTHandles.Alloc(m_IntermediateDesc, FilterMode.Point, TextureWrapMode.Clamp, name: _IntermediateRTNames[0]);
+            m_Intermediate[1] = RTHandles.Alloc(m_IntermediateDesc, FilterMode.Point, TextureWrapMode.Clamp, name: _IntermediateRTNames[1]);
+        }
+
+        public override void OnCameraCleanup(CommandBuffer cmd)
+        {
+            base.OnCameraCleanup(cmd);
+            for (int i = 0; i < m_Intermediate.Length; i++)
+            {
+                m_Intermediate[i].Release();
+            }
         }
 
         public override void Configure(CommandBuffer cmd, RenderTextureDescriptor cameraTextureDescriptor)
@@ -248,7 +243,8 @@ namespace UnityEngine.Rendering.Universal.PostProcessing {
         /// </summary>
         /// <param name="renderingData">Current rendering data</param>
         /// <returns>True if any renderer will be executed for the given camera. False Otherwise.</returns>
-        public bool PrepareRenderers(ref RenderingData renderingData){
+        public bool PrepareRenderers(ref RenderingData renderingData)
+        {
             // See if current camera is a scene view camera to skip renderers with "visibleInSceneView" = false.
             bool isSceneView = renderingData.cameraData.cameraType == CameraType.SceneView;
 
@@ -257,12 +253,14 @@ namespace UnityEngine.Rendering.Universal.PostProcessing {
 
             // Collect the active renderers
             m_ActivePostProcessRenderers.Clear();
-            for(int index = 0; index < m_PostProcessRenderers.Count; index++){
+            for (int index = 0; index < m_PostProcessRenderers.Count; index++)
+            {
                 var ppRenderer = m_PostProcessRenderers[index];
                 // Skips current renderer if "visibleInSceneView" = false and the current camera is a scene view camera. 
-                if(isSceneView && !ppRenderer.visibleInSceneView) continue;
+                if (isSceneView && !ppRenderer.visibleInSceneView) continue;
                 // Setup the camera for the renderer and if it will render anything, add to active renderers and get its required inputs
-                if(ppRenderer.Setup(ref renderingData, injectionPoint)){
+                if (ppRenderer.Setup(ref renderingData, injectionPoint))
+                {
                     m_ActivePostProcessRenderers.Add(index);
                     passInput |= ppRenderer.input;
                 }
@@ -282,76 +280,77 @@ namespace UnityEngine.Rendering.Universal.PostProcessing {
         /// <param name="renderingData">Current rendering data</param>
         public override void Execute(ScriptableRenderContext context, ref RenderingData renderingData)
         {
-            RenderTargetIdentifier target = renderingData.cameraData.renderer.cameraColorTarget;
-
-            // Copy camera target description for intermediate RTs. Disable multisampling and depth buffer for the intermediate targets.
-            m_IntermediateDesc = renderingData.cameraData.cameraTargetDescriptor;
-            m_IntermediateDesc.msaaSamples = 1;
-            m_IntermediateDesc.depthBufferBits = 0;
-
+            RTHandle target = renderingData.cameraData.renderer.cameraColorTargetHandle;
             CommandBuffer cmd = CommandBufferPool.Get(m_PassName);
-            
+
             context.ExecuteCommandBuffer(cmd);
             cmd.Clear();
 
             int width = m_IntermediateDesc.width;
             int height = m_IntermediateDesc.height;
-            cmd.SetGlobalVector("_ScreenSize", new Vector4(width, height, 1.0f/width, 1.0f/height));
-            
+            cmd.SetGlobalVector("_ScreenSize", new Vector4(width, height, 1.0f / width, 1.0f / height));
+
             // The variable will be true if the last renderer couldn't blit to destination.
             // This happens if there is only 1 renderer and the source is the same as the destination.
             bool requireBlitBack = false;
             // The current intermediate RT to use as a source.
             int intermediateIndex = 0;
 
-            for(int index = 0; index < m_ActivePostProcessRenderers.Count; ++index){
+            for (int index = 0; index < m_ActivePostProcessRenderers.Count; ++index)
+            {
                 var rendererIndex = m_ActivePostProcessRenderers[index];
                 var renderer = m_PostProcessRenderers[rendererIndex];
-                
-                RenderTargetIdentifier source, destination;
-                if(index == 0){
+
+                RTHandle source, destination;
+                if (index == 0)
+                {
                     // If this is the first renderers then the source will be the external source (not intermediate).
                     source = target;
-                    if(m_ActivePostProcessRenderers.Count == 1){
-                            // Since we can't bind the same RT as a texture and a render target at the same time, we will blit to an intermediate RT.
-                        destination = GetIntermediate(cmd, 0);
+                    if (m_ActivePostProcessRenderers.Count == 1)
+                    {
+                        // Since we can't bind the same RT as a texture and a render target at the same time, we will blit to an intermediate RT.
+                        destination = m_Intermediate[0];
                         // Then we will blit back to the destination.
                         requireBlitBack = true;
-                    } else {
-                        // If there is more than one renderer, we will need to the intermediate RT anyway.
-                        destination = GetIntermediate(cmd, intermediateIndex);
                     }
-                } else {
+                    else
+                    {
+                        // If there is more than one renderer, we will need to the intermediate RT anyway.
+                        destination = m_Intermediate[intermediateIndex];
+                    }
+                }
+                else
+                {
                     // If this is not the first renderer, we will want to the read from the intermediate RT.
-                    source = GetIntermediate(cmd, intermediateIndex);
-                    if(index == m_ActivePostProcessRenderers.Count - 1){
+                    source = m_Intermediate[intermediateIndex];
+                    if (index == m_ActivePostProcessRenderers.Count - 1)
+                    {
                         // If this is the last renderer, blit to the destination directly.
                         destination = target;
-                    } else {
+                    }
+                    else
+                    {
                         // Otherwise, flip the intermediate RT index and set as destination.
                         // This will act as a ping pong process between the 2 RT where color data keeps moving back and forth while being processed on each pass.
                         intermediateIndex = 1 - intermediateIndex;
-                        destination = GetIntermediate(cmd, intermediateIndex);
+                        destination = m_Intermediate[intermediateIndex];
                     }
                 }
 
-                using(new ProfilingScope(cmd, m_ProfilingSamplers[rendererIndex]))
+                using (new ProfilingScope(cmd, m_ProfilingSamplers[rendererIndex]))
                 {
                     // If the renderer was not already initialized, initialize it.
-                    if(!renderer.Initialized)
+                    if (!renderer.Initialized)
                         renderer.InitializeInternal();
                     // Execute the renderer.
                     renderer.Render(cmd, source, destination, ref renderingData, injectionPoint);
                 }
-                
+
             }
 
             // If blit back is needed, blit from the intermediate RT to the destination (see above for explanation)
-            if(requireBlitBack)
-                Blit(cmd, m_Intermediate[0].Identifier(), target);
-            
-            // Release allocated Intermediate RTs.
-            CleanupIntermediate(cmd);
+            if (requireBlitBack)
+                Blit(cmd, m_Intermediate[0], target);
 
             // Send command buffer for execution, then release it.
             context.ExecuteCommandBuffer(cmd);

--- a/package.json
+++ b/package.json
@@ -3,11 +3,11 @@
   "version": "2.0.0",
   "displayName": "Universal RP Post-Processing Stack",
   "description": "A post-processing stack for Universal RP",
-  "unity": "2020.2",
+  "unity": "2021.2",
   "unityRelease": "0f1",
   "dependencies": {
-    "com.unity.render-pipelines.universal": "10.2.2",
-    "com.unity.render-pipelines.core": "10.2.2"
+    "com.unity.render-pipelines.universal": "12.1.0",
+    "com.unity.render-pipelines.core": "12.1.0"
   },
   "keywords": [
     "graphics",


### PR DESCRIPTION
Although currently everything still works with URP13, with the new version Unity has made the RenderTargetHandle based API obsolete.  This PR swaps it to use RTHandles.